### PR TITLE
Add thirty bees support

### DIFF
--- a/lib/CloudSwipe/Http.php
+++ b/lib/CloudSwipe/Http.php
@@ -68,6 +68,12 @@ class CloudSwipeHttp
 
     public function request($method, $url, $options=[])
     {
+        if (defined('_TB_VERSION_')) {
+            $request = $this->client->request($method, $url, $options);
+
+            return $request;
+        }
+
         $request = $this->client->createRequest($method, $url, $options);
 
         return $this->client->send($request);

--- a/lib/CloudSwipe/LineTotals.php
+++ b/lib/CloudSwipe/LineTotals.php
@@ -40,6 +40,7 @@ class CloudSwipeLineTotals
     {
         $lineTotals = new self();
 
+        /** @var Cart $psCart */
         $psSummary = $psCart->getSummaryDetails();
         $psCurrency = Currency::getCurrencyInstance((int)$psCart->id_currency);
 

--- a/views/templates/front/confirmation.tpl
+++ b/views/templates/front/confirmation.tpl
@@ -1,0 +1,45 @@
+{**
+* The MIT License (MIT)
+*
+* Copyright (c) 2017 CloudSwipe
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*
+* @author Joey Beninghove
+* @copyright 2017 CloudSwipe
+* @license https://opensource.org/licenses/MIT MIT
+*}
+{if isset($status) && ($status == 'ok')}
+    <h3>{l s='Your order on %s is complete.' sprintf=[$shop_name] mod='cloudswipepayments'}</h3>
+    <p>
+        <br/>- {l s='Amount' mod='cloudswipepayments'} : <span class="price"><strong>{$total|escape:'htmlall':'UTF-8'}</strong></span>
+        <br/>- {l s='Reference' mod='cloudswipepayments'} : <span class="reference"><strong>{$reference|escape:'html':'UTF-8'}</strong></span>
+        <br/><br/>{l s='An email has been sent with this information.' mod='cloudswipepayments'}
+        <br/><br/>{l s='If you have questions, comments or concerns, please contact our' mod='cloudswipepayments'} <a href="{$link->getPageLink('contact', true)|escape:'html':'UTF-8'}">{l s='expert customer support team.' mod='cloudswipepayments'}</a>
+    </p>
+{else}
+    <h3>{l s='Your order on %s has not been accepted.' sprintf=[$shop_name] mod='cloudswipepayments'}</h3>
+    <p>
+    <p>
+        <br/>- {l s='Reference' mod='cloudswipepayments'} <span class="reference"> <strong>{$reference|escape:'html':'UTF-8'}</strong></span>
+        <br/><br/>{l s='Please, try to order again.' mod='cloudswipepayments'}
+        <br/><br/>{l s='If you have questions, comments or concerns, please contact our' mod='cloudswipepayments'} <a href="{$link->getPageLink('contact', true)|escape:'html':'UTF-8'}">{l s='expert customer support team.' mod='cloudswipepayments'}</a>
+    </p>
+{/if}
+<hr/>

--- a/views/templates/hook/payment.tpl
+++ b/views/templates/hook/payment.tpl
@@ -1,5 +1,4 @@
-<?php
-/**
+{**
 * The MIT License (MIT)
 *
 * Copyright (c) 2017 CloudSwipe
@@ -22,25 +21,18 @@
 * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 * SOFTWARE.
 *
-* @author    Joey Beninghove
+* @author Joey Beninghove
 * @copyright 2017 CloudSwipe
-* @license   https://opensource.org/licenses/MIT MIT
-*/
+* @license https://opensource.org/licenses/MIT MIT
+*}
 
-class CloudSwipePaymentsSlurpModuleFrontController extends ModuleFrontController
-{
-    public function initContent()
-    {
-        parent::initContent();
-
-        if (defined('_TB_VERSION_')) {
-            $this->context->smarty->assign(array(
-                'status' => 'ok',
-            ));
-
-            $this->setTemplate(_PS_MODULE_DIR_.'cloudswipepayment/views/templates/front/confirmation.tpl');
-        } else {
-            $this->setTemplate("module:cloudswipepayments/views/templates/front/slurp.tpl");
-        }
-    }
-}
+<div class="row">
+    <div class="col-xs-12 col-md-12">
+        <p class="payment_module" id="cloudswipe_payment_button">
+            <a id="cloudswipe_payment_link" href="{$cloudswipe_payment_page|escape:'htmlall':'UTf-8'}" title="{l s='Pay by Credit Card' mod='cloudswipepayments'}">
+                {*<img src="{$module_dir|escape:'htmlall':'UTF-8'}/views/img/creditcardlogos.jpg" height="64px" width="auto" alt="{l s='Credit cards' mod='cloudswipepayments'}"/>*}
+                {l s='Pay by Credit Card' mod='cloudswipepayments'}
+            </a>
+        </p>
+    </div>
+</div>


### PR DESCRIPTION
This PR adds support for thirty bees.

The following is changed:
- Support thirty bees' version of Guzzle: 6.0
- Adds a payment hook (`hookDisplayPayment`) for the payment page
- Special order confirmation template for thirty bees
- Which is served by the new `hookPaymentReturn` hook
- Set `ps_versions_compliancy` min to 1.6 (because thirty bees still respects that setting)